### PR TITLE
feat: Native 기능 호환 체크를 iOS까지 공용 모듈로 분리

### DIFF
--- a/components/common/bottomNav.js
+++ b/components/common/bottomNav.js
@@ -1,4 +1,5 @@
 import KlasNativeBridge from '../../lib/core/klasNativeBridge';
+import { isNativeFeatureCompatible } from '../../lib/core/nativeApp';
 import { useSyncExternalStore } from "react";
 import IonIcon from "@reacticons/ionicons";
 import Spacer from "../common/spacer";
@@ -12,24 +13,9 @@ const TAB_ITEMS = [
     { key: "menu", label: "전체", icon: "grid-outline", href: "/profile" }
 ];
 
-const checkAppCompatibility = (version) => {
-    if (!version) return false;
-    return version >= 24;
-};
-
-const getAppVersionFromUserAgent = () => {
-    if (typeof window === 'undefined') return null;
-    const userAgent = navigator.userAgent;
-    const match = userAgent.match(/AndroidApp_v(\d+)/);
-    return match ? parseInt(match[1], 10) : null;
-};
-
 const emptySubscribe = () => () => { };
 
-const getClientCompat = () => {
-    const appVersion = getAppVersionFromUserAgent();
-    return appVersion ? checkAppCompatibility(appVersion) : false;
-};
+const getClientCompat = () => isNativeFeatureCompatible("bottomNav");
 
 const getServerCompat = () => false;
 

--- a/components/common/header.js
+++ b/components/common/header.js
@@ -2,25 +2,9 @@ import { useEffect, useState } from "react";
 import IonIcon from "@reacticons/ionicons";
 import Spacer from "../common/spacer";
 import KlasNativeBridge from "../../lib/core/klasNativeBridge";
+import { getNativeAppFromUserAgent, isNativeFeatureCompatible } from "../../lib/core/nativeApp";
 import toast, { Toaster } from 'react-hot-toast';
 import GradualBlur from "../common/GradualBlur";
-
-
-const checkAppCompatibility = (version) => {
-    if (!version) return false;
-    return version >= 21;
-};
-
-const checkAgentCompatibility = (version) => {
-    if (!version) return false;
-    return version >= 23;
-};
-
-const getAppVersionFromUserAgent = () => {
-    const userAgent = navigator.userAgent;
-    const match = userAgent.match(/AndroidApp_v(\d+)/);
-    return match ? parseInt(match[1], 10) : null;
-};
 
 const handleChangelogClick = () => {
     try {
@@ -44,11 +28,11 @@ function Header({ title }) {
     const [isAgentCompatible, setIsAgentCompatible] = useState(false);
 
     useEffect(() => {
-        const appVersion = getAppVersionFromUserAgent();
-        if (appVersion) {
-            setVersion(appVersion);
-            setIsCompatible(checkAppCompatibility(appVersion));
-            setIsAgentCompatible(checkAgentCompatibility(appVersion));
+        const app = getNativeAppFromUserAgent();
+        if (app) {
+            setVersion(app.version);
+            setIsCompatible(isNativeFeatureCompatible("header", app));
+            setIsAgentCompatible(isNativeFeatureCompatible("agent", app));
         }
     }, []);
 

--- a/lib/core/nativeApp.js
+++ b/lib/core/nativeApp.js
@@ -1,0 +1,31 @@
+// TODO: 환경변수로 관리
+const NATIVE_FEATURE_MIN_VERSIONS = {
+    header: { android: 21, ios: 1 },
+    agent: { android: 23, ios: 1 },
+    bottomNav: { android: 24, ios: 1 },
+};
+
+export const getNativeAppFromUserAgent = () => {
+    if (typeof window === "undefined") return null;
+    const userAgent = navigator.userAgent;
+    const android = userAgent.match(/AndroidApp_v(\d+)/);
+    if (android) {
+        return { platform: "android", version: parseInt(android[1], 10) };
+    }
+    const ios = userAgent.match(/iOSApp_v(\d+)/);
+    if (ios) {
+        return { platform: "ios", version: parseInt(ios[1], 10) };
+    }
+    return null;
+};
+
+export const checkNativeAppCompatibility = (app, minVersions) => {
+    if (!app) return false;
+    const minVersion = minVersions?.[app.platform];
+    if (minVersion == null) return false;
+    return app.version >= minVersion;
+};
+
+export const isNativeFeatureCompatible = (feature, app = getNativeAppFromUserAgent()) => {
+    return checkNativeAppCompatibility(app, NATIVE_FEATURE_MIN_VERSIONS[feature]);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 export * from './core/klasNativeBridge';
+export * from './core/nativeApp';
 export * from './core/constants';
 export * from './core/klas';
 export * from './core/normalizeBuildingName';


### PR DESCRIPTION
header와 bottomNav가 앱 버전을 `AndroidApp_v User-Agent`로만 판별해서, iOS 앱에서는 해당 UI가 아예 안 떴습니다. 버전 컷라인도 각 컴포넌트에 흩어져 있어 Android/iOS 최소 버전을 한곳에서 관리하기 어려웠습니다. `lib/core/nativeApp.js`에서 `AndroidApp_v1` / `iOSApp_v`를 파싱하고, 기능별 최소 버전(header, agent, bottomNav)을 기준으로 호환 여부를 판단하도록 모았습니다. header와 bottomNav는 isNativeFeatureCompatible()만 호출합니다.